### PR TITLE
docs: updated create provider "option three" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,20 +178,20 @@ export class AppModule {}
             ```
             import {Injectable} from '@angular/core';
             import {map} from 'rxjs/operators';
-
+            
             import {HttpClient} from '@angular/common/http';
-
+            
             import {AutoCompleteService} from 'ionic4-auto-complete';
-
+            
             @Injectable()
             export class CompleteTestService implements AutoCompleteService {
               labelAttribute = 'name';
               formValueAttribute = 'numericCode';
-
+            
               constructor(private http:HttpClient) {
               
               }
-
+            
               getResults(keyword:string) {
                  if (!keyword) { return false; }
 

--- a/README.md
+++ b/README.md
@@ -178,32 +178,34 @@ export class AppModule {}
             ```
             import {Injectable} from '@angular/core';
             import {map} from 'rxjs/operators';
-            
+
             import {HttpClient} from '@angular/common/http';
-            
+
             import {AutoCompleteService} from 'ionic4-auto-complete';
-            
+
             @Injectable()
             export class CompleteTestService implements AutoCompleteService {
               labelAttribute = 'name';
               formValueAttribute = 'numericCode';
-            
-              constructor(private http:Http) {
+
+              constructor(private http:HttpClient) {
               
               }
-            
+
               getResults(keyword:string) {
-                 return this.http.get('https://restcountries.eu/rest/v1/name/' + keyword).map(
-                    (result) => {
-                       return result.json().filter(
+                 if (!keyword) { return false; }
+
+                 return this.http.get('https://restcountries.eu/rest/v2/name/' + keyword).pipe(map(
+                    (result: any[]) => {
+                       return result.filter(
                           (item) => {
-                             item.name.toLowerCase().startsWith(
+                             return item.name.toLowerCase().startsWith(
                                 keyword.toLowerCase()
                              );
                           }
                        );
                     }
-                 );
+                 ));
               }
             }
             ```


### PR DESCRIPTION
Hey @jrquick17, sorry to spam the pull requests but I'm back with another fix to the readme - I was having trouble getting option 3 of the 'create provider' instructions working but it's good to go now!

# I'm submitting a...

- [ ] Bug Fix
- [ ] Feature
- [x] Other (Refactoring, Added tests, Documentation, ...)

### Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
- [x] Docs have been added / updated (for bug fixes / features)

### Description
Fixed create provider "option three" example:

- updated restcountries.eu api to v2
- added `.pipe()` which is now required for `.map()` in rxjs 6.0+, from [the rxjs changelog](https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#breaking-changes-7)
- removed `.json()` which is invalid

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Does this PR affects any existing issues?

- [ ] Yes
- [x] No
