### PR TITLE
feat: allow custom styles to be passed to elements within the Shadow DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ npm install ionic4-auto-complete --save
     
 * In addition to the searchbar options, `ion-auto-complete` also supports the following option attributes:
     
+* `[styles]` (AutoCompleteStyles) - custom styles to be passed to `ngStyle` on elements within the Shadow DOM. Available element keys are: `list`; `listItem`; and `searchbar`.
 * `[template]` (TemplateRef) - custom template reference for your auto complete items (see below).
 * `[emptytemplate]` (TemplateRef) - custom template reference for your auto complete no items display.
 * `[selectionTemplate]` (TemplateRef) - custom template reference for your own selection display when using multi.

--- a/docs/classes/AutoCompleteStyles.html
+++ b/docs/classes/AutoCompleteStyles.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html class="no-js" lang="">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>ionic4-auto-complete</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
+	      <link rel="stylesheet" href="../styles/style.css">
+    </head>
+    <body>
+
+        <div class="navbar navbar-default navbar-fixed-top visible-xs">
+            <a href="../" class="navbar-brand">ionic4-auto-complete</a>
+            <button type="button" class="btn btn-default btn-menu ion-ios-menu" id="btn-menu"></button>
+        </div>
+
+        <div class="xs-menu menu" id="mobile-menu">
+                <div id="book-search-input" role="search"><input type="text" placeholder="Type to search"></div>            <compodoc-menu></compodoc-menu>
+        </div>
+
+        <div class="container-fluid main">
+           <div class="row main">
+               <div class="hidden-xs menu">
+                   <compodoc-menu mode="normal"></compodoc-menu>
+               </div>
+               <!-- START CONTENT -->
+               <div class="content class">
+                   <div class="content-data">
+
+
+
+
+
+
+
+
+
+
+
+<ol class="breadcrumb">
+  <li>Classes</li>
+  <li>AutoCompleteStyles</li>
+</ol>
+
+<ul class="nav nav-tabs" role="tablist">
+        <li class="active">
+            <a href="#info" role="tab" id="info-tab" data-toggle="tab" data-link="info">Info</a>
+        </li>
+        <li >
+            <a href="#source" role="tab" id="source-tab" data-toggle="tab" data-link="source">Source</a>
+        </li>
+</ul>
+
+<div class="tab-content">
+    <div class="tab-pane fade active in" id="c-info">
+        <p class="comment">
+            <h3>File</h3>
+        </p>
+        <p class="comment">
+            <code>src/auto-complete-styles.model.ts</code>
+        </p>
+
+
+
+
+
+            <section>
+    <h3 id="index">Index</h3>
+    <table class="table table-sm table-bordered index-table">
+        <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <h6><b>Properties</b></h6>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <ul class="index-list">
+                            <li>
+                                    <span class="modifier">Public</span>
+                                <a href="#list">list</a>
+                            </li>
+                            <li>
+                                    <span class="modifier">Public</span>
+                                <a href="#listItem">listItem</a>
+                            </li>
+                            <li>
+                                    <span class="modifier">Public</span>
+                                <a href="#searchbar">searchbar</a>
+                            </li>
+                        </ul>
+                    </td>
+                </tr>
+
+
+
+
+
+
+        </tbody>
+    </table>
+</section>
+
+
+            <section>
+    
+        <h3 id="inputs">
+            Properties
+        </h3>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="list"></a>
+                        <span class="name">
+                            <b>
+                                <span class="modifier">Public</span>
+                            list</b>
+                            <a href="#list"><span class="icon ion-ios-link"></span></a>
+                        </span>
+                    </td>
+                </tr>
+                    <tr>
+                        <td class="col-md-4">
+                            <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/object" target="_blank" >object</a></code>
+
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="col-md-4">
+                            <i>Default value : </i><code>{}</code>
+                        </td>
+                    </tr>
+                        <tr>
+                            <td class="col-md-4">
+                                    <div class="io-line">Defined in <a href="" data-line="2" class="link-to-prism">src/auto-complete-styles.model.ts:2</a></div>
+                            </td>
+                        </tr>
+
+
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="listItem"></a>
+                        <span class="name">
+                            <b>
+                                <span class="modifier">Public</span>
+                            listItem</b>
+                            <a href="#listItem"><span class="icon ion-ios-link"></span></a>
+                        </span>
+                    </td>
+                </tr>
+                    <tr>
+                        <td class="col-md-4">
+                            <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/object" target="_blank" >object</a></code>
+
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="col-md-4">
+                            <i>Default value : </i><code>{}</code>
+                        </td>
+                    </tr>
+                        <tr>
+                            <td class="col-md-4">
+                                    <div class="io-line">Defined in <a href="" data-line="3" class="link-to-prism">src/auto-complete-styles.model.ts:3</a></div>
+                            </td>
+                        </tr>
+
+
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="searchbar"></a>
+                        <span class="name">
+                            <b>
+                                <span class="modifier">Public</span>
+                            searchbar</b>
+                            <a href="#searchbar"><span class="icon ion-ios-link"></span></a>
+                        </span>
+                    </td>
+                </tr>
+                    <tr>
+                        <td class="col-md-4">
+                            <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/object" target="_blank" >object</a></code>
+
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="col-md-4">
+                            <i>Default value : </i><code>{}</code>
+                        </td>
+                    </tr>
+                        <tr>
+                            <td class="col-md-4">
+                                    <div class="io-line">Defined in <a href="" data-line="4" class="link-to-prism">src/auto-complete-styles.model.ts:4</a></div>
+                            </td>
+                        </tr>
+
+
+            </tbody>
+        </table>
+</section>
+
+
+
+
+
+
+
+    </div>
+
+
+    <div class="tab-pane fade  tab-source-code" id="c-source">
+        <pre class="line-numbers compodoc-sourcecode"><code class="language-typescript">export class AutoCompleteStyles {
+  public list &#x3D; {};
+  public listItem &#x3D; {};
+  public searchbar &#x3D; {};
+}
+</code></pre>
+    </div>
+</div>
+
+
+
+                   
+
+
+
+
+                   </div><div class="search-results">
+    <div class="has-results">
+        <h1 class="search-results-title"><span class='search-results-count'></span> result-matching "<span class='search-query'></span>"</h1>
+        <ul class="search-results-list"></ul>
+    </div>
+    <div class="no-results">
+        <h1 class="search-results-title">No results matching "<span class='search-query'></span>"</h1>
+    </div>
+</div>
+</div>
+               <!-- END CONTENT -->
+           </div>
+       </div>
+
+       <script>
+            var COMPODOC_CURRENT_PAGE_DEPTH = 1;
+            var COMPODOC_CURRENT_PAGE_CONTEXT = 'class';
+            var COMPODOC_CURRENT_PAGE_URL = 'AutoCompleteStyles.html';
+            var MAX_SEARCH_RESULTS = 15;
+       </script>
+
+       <script src="../js/libs/custom-elements.min.js"></script>
+       <script src="../js/libs/lit-html.js"></script>
+       <!-- Required to polyfill modern browsers as code is ES5 for IE... -->
+       <script src="../js/libs/custom-elements-es5-adapter.js" charset="utf-8" defer></script>
+       <script src="../js/menu-wc.js" defer></script>
+
+       <script src="../js/libs/bootstrap-native.js"></script>
+
+       <script src="../js/libs/es6-shim.min.js"></script>
+       <script src="../js/libs/EventDispatcher.js"></script>
+       <script src="../js/libs/promise.min.js"></script>
+       <script src="../js/libs/zepto.min.js"></script>
+
+       <script src="../js/compodoc.js"></script>
+
+       <script src="../js/tabs.js"></script>
+       <script src="../js/menu.js"></script>
+       <script src="../js/libs/clipboard.min.js"></script>
+       <script src="../js/libs/prism.js"></script>
+       <script src="../js/sourceCode.js"></script>
+          <script src="../js/search/search.js"></script>
+          <script src="../js/search/lunr.min.js"></script>
+          <script src="../js/search/search-lunr.js"></script>
+          <script src="../js/search/search_index.js"></script>
+       <script src="../js/lazy-load-graphs.js"></script>
+
+
+    </body>
+</html>

--- a/docs/components/AutoCompleteComponent.html
+++ b/docs/components/AutoCompleteComponent.html
@@ -243,10 +243,6 @@
                             </li>
                             <li>
                                     <span class="modifier">Public</span>
-                                <a href="#getStyle">getStyle</a>
-                            </li>
-                            <li>
-                                    <span class="modifier">Public</span>
                                 <a href="#getValue">getValue</a>
                             </li>
                             <li>
@@ -269,6 +265,14 @@
                             </li>
                             <li>
                                 <a href="#keyupIonSearchbar">keyupIonSearchbar</a>
+                            </li>
+                            <li>
+                                    <span class="modifier">Private</span>
+                                <a href="#listLocationStyles">listLocationStyles</a>
+                            </li>
+                            <li>
+                                    <span class="modifier">Public</span>
+                                <a href="#listStyles">listStyles</a>
                             </li>
                             <li>
                                 <a href="#ngAfterViewChecked">ngAfterViewChecked</a>
@@ -418,6 +422,9 @@
                                 <a href="#showResultsFirst">showResultsFirst</a>
                             </li>
                             <li>
+                                <a href="#styles">styles</a>
+                            </li>
+                            <li>
                                 <a href="#template">template</a>
                             </li>
                             <li>
@@ -527,7 +534,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="152" class="link-to-prism">src/auto-complete/auto-complete.component.ts:152</a></div>
+                                <div class="io-line">Defined in <a href="" data-line="154" class="link-to-prism">src/auto-complete/auto-complete.component.ts:154</a></div>
                             </td>
                         </tr>
 
@@ -585,7 +592,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="37" class="link-to-prism">src/auto-complete/auto-complete.component.ts:37</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="38" class="link-to-prism">src/auto-complete/auto-complete.component.ts:38</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -611,7 +618,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="39" class="link-to-prism">src/auto-complete/auto-complete.component.ts:39</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="40" class="link-to-prism">src/auto-complete/auto-complete.component.ts:40</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -632,7 +639,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="40" class="link-to-prism">src/auto-complete/auto-complete.component.ts:40</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="41" class="link-to-prism">src/auto-complete/auto-complete.component.ts:41</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -658,7 +665,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="41" class="link-to-prism">src/auto-complete/auto-complete.component.ts:41</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="42" class="link-to-prism">src/auto-complete/auto-complete.component.ts:42</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -679,7 +686,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="88" class="link-to-prism">src/auto-complete/auto-complete.component.ts:88</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="90" class="link-to-prism">src/auto-complete/auto-complete.component.ts:90</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -700,7 +707,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="42" class="link-to-prism">src/auto-complete/auto-complete.component.ts:42</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="43" class="link-to-prism">src/auto-complete/auto-complete.component.ts:43</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -726,7 +733,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="38" class="link-to-prism">src/auto-complete/auto-complete.component.ts:38</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="39" class="link-to-prism">src/auto-complete/auto-complete.component.ts:39</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -752,7 +759,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="43" class="link-to-prism">src/auto-complete/auto-complete.component.ts:43</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="44" class="link-to-prism">src/auto-complete/auto-complete.component.ts:44</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -778,7 +785,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="44" class="link-to-prism">src/auto-complete/auto-complete.component.ts:44</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="45" class="link-to-prism">src/auto-complete/auto-complete.component.ts:45</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -804,7 +811,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="45" class="link-to-prism">src/auto-complete/auto-complete.component.ts:45</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="46" class="link-to-prism">src/auto-complete/auto-complete.component.ts:46</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -825,7 +832,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="46" class="link-to-prism">src/auto-complete/auto-complete.component.ts:46</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="47" class="link-to-prism">src/auto-complete/auto-complete.component.ts:47</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -851,7 +858,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="47" class="link-to-prism">src/auto-complete/auto-complete.component.ts:47</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="48" class="link-to-prism">src/auto-complete/auto-complete.component.ts:48</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -877,7 +884,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="48" class="link-to-prism">src/auto-complete/auto-complete.component.ts:48</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="49" class="link-to-prism">src/auto-complete/auto-complete.component.ts:49</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -903,7 +910,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="49" class="link-to-prism">src/auto-complete/auto-complete.component.ts:49</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="50" class="link-to-prism">src/auto-complete/auto-complete.component.ts:50</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -924,7 +931,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="64" class="link-to-prism">src/auto-complete/auto-complete.component.ts:64</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="66" class="link-to-prism">src/auto-complete/auto-complete.component.ts:66</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -950,7 +957,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="50" class="link-to-prism">src/auto-complete/auto-complete.component.ts:50</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="51" class="link-to-prism">src/auto-complete/auto-complete.component.ts:51</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -976,7 +983,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="51" class="link-to-prism">src/auto-complete/auto-complete.component.ts:51</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="52" class="link-to-prism">src/auto-complete/auto-complete.component.ts:52</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1002,7 +1009,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="52" class="link-to-prism">src/auto-complete/auto-complete.component.ts:52</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="53" class="link-to-prism">src/auto-complete/auto-complete.component.ts:53</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1028,7 +1035,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="53" class="link-to-prism">src/auto-complete/auto-complete.component.ts:53</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="54" class="link-to-prism">src/auto-complete/auto-complete.component.ts:54</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1054,7 +1061,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="54" class="link-to-prism">src/auto-complete/auto-complete.component.ts:54</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="55" class="link-to-prism">src/auto-complete/auto-complete.component.ts:55</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1080,7 +1087,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="55" class="link-to-prism">src/auto-complete/auto-complete.component.ts:55</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="56" class="link-to-prism">src/auto-complete/auto-complete.component.ts:56</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1106,7 +1113,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="56" class="link-to-prism">src/auto-complete/auto-complete.component.ts:56</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="57" class="link-to-prism">src/auto-complete/auto-complete.component.ts:57</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1132,7 +1139,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="57" class="link-to-prism">src/auto-complete/auto-complete.component.ts:57</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="58" class="link-to-prism">src/auto-complete/auto-complete.component.ts:58</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1153,7 +1160,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="58" class="link-to-prism">src/auto-complete/auto-complete.component.ts:58</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="59" class="link-to-prism">src/auto-complete/auto-complete.component.ts:59</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1174,7 +1181,33 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="59" class="link-to-prism">src/auto-complete/auto-complete.component.ts:59</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="60" class="link-to-prism">src/auto-complete/auto-complete.component.ts:60</a></div>
+                            </td>
+                        </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="styles"></a>
+                        <b>styles</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="../classes/AutoCompleteStyles.html" target="_self" >AutoCompleteStyles</a></code>
+
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Default value : </i><code>new AutoCompleteStyles</code>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="61" class="link-to-prism">src/auto-complete/auto-complete.component.ts:61</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1195,7 +1228,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="60" class="link-to-prism">src/auto-complete/auto-complete.component.ts:60</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="62" class="link-to-prism">src/auto-complete/auto-complete.component.ts:62</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1221,7 +1254,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="61" class="link-to-prism">src/auto-complete/auto-complete.component.ts:61</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="63" class="link-to-prism">src/auto-complete/auto-complete.component.ts:63</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1245,7 +1278,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="96" class="link-to-prism">src/auto-complete/auto-complete.component.ts:96</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="98" class="link-to-prism">src/auto-complete/auto-complete.component.ts:98</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1266,7 +1299,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="95" class="link-to-prism">src/auto-complete/auto-complete.component.ts:95</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="97" class="link-to-prism">src/auto-complete/auto-complete.component.ts:97</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1287,7 +1320,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="94" class="link-to-prism">src/auto-complete/auto-complete.component.ts:94</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="96" class="link-to-prism">src/auto-complete/auto-complete.component.ts:96</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1308,7 +1341,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="97" class="link-to-prism">src/auto-complete/auto-complete.component.ts:97</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="99" class="link-to-prism">src/auto-complete/auto-complete.component.ts:99</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1329,7 +1362,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="98" class="link-to-prism">src/auto-complete/auto-complete.component.ts:98</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="100" class="link-to-prism">src/auto-complete/auto-complete.component.ts:100</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1350,7 +1383,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="102" class="link-to-prism">src/auto-complete/auto-complete.component.ts:102</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="104" class="link-to-prism">src/auto-complete/auto-complete.component.ts:104</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1371,7 +1404,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="99" class="link-to-prism">src/auto-complete/auto-complete.component.ts:99</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="101" class="link-to-prism">src/auto-complete/auto-complete.component.ts:101</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1392,7 +1425,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="100" class="link-to-prism">src/auto-complete/auto-complete.component.ts:100</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="102" class="link-to-prism">src/auto-complete/auto-complete.component.ts:102</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1413,7 +1446,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="103" class="link-to-prism">src/auto-complete/auto-complete.component.ts:103</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="105" class="link-to-prism">src/auto-complete/auto-complete.component.ts:105</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1434,7 +1467,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="101" class="link-to-prism">src/auto-complete/auto-complete.component.ts:101</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="103" class="link-to-prism">src/auto-complete/auto-complete.component.ts:103</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1455,7 +1488,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="104" class="link-to-prism">src/auto-complete/auto-complete.component.ts:104</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="106" class="link-to-prism">src/auto-complete/auto-complete.component.ts:106</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1476,7 +1509,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="85" class="link-to-prism">src/auto-complete/auto-complete.component.ts:85</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="87" class="link-to-prism">src/auto-complete/auto-complete.component.ts:87</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1511,8 +1544,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="234"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:234</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="236"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:236</a></div>
                 </td>
             </tr>
 
@@ -1556,8 +1589,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="273"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:273</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="275"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:275</a></div>
                 </td>
             </tr>
 
@@ -1624,8 +1657,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="562"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:562</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="570"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:570</a></div>
                 </td>
             </tr>
 
@@ -1696,8 +1729,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="308"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:308</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="310"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:310</a></div>
                 </td>
             </tr>
 
@@ -1772,8 +1805,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="297"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:297</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="299"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:299</a></div>
                 </td>
             </tr>
 
@@ -1813,8 +1846,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="251"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:251</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="253"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:253</a></div>
                 </td>
             </tr>
 
@@ -1887,8 +1920,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="336"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:336</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="338"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:338</a></div>
                 </td>
             </tr>
 
@@ -1973,8 +2006,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="401"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:401</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="403"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:403</a></div>
                 </td>
             </tr>
 
@@ -2047,8 +2080,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="433"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:433</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="435"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:435</a></div>
                 </td>
             </tr>
 
@@ -2060,49 +2093,6 @@
 
                     <div class="io-description">
                         <b>Returns : </b>    <code>any | []</code>
-
-                    </div>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <table class="table table-sm table-bordered">
-        <tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="getStyle"></a>
-                    <span class="name">
-                        <b>
-                            <span class="modifier">Public</span>
-                            getStyle
-                        </b>
-                        <a href="#getStyle"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
-            <tr>
-                <td class="col-md-4">
-                    <span class="modifier-icon icon ion-ios-reset"></span>
-                    <code>getStyle()</code>
-                </td>
-            </tr>
-
-
-            <tr>
-                <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="444"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:444</a></div>
-                </td>
-            </tr>
-
-
-            <tr>
-                <td class="col-md-4">
-                    <div class="io-description"><p>Get menu style</p>
-</div>
-
-                    <div class="io-description">
-                        <b>Returns : </b>        <code><a href="https://www.typescriptlang.org/docs/handbook/basic-types.html" target="_blank" >any</a></code>
 
                     </div>
                 </td>
@@ -2133,8 +2123,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="472"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:472</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="480"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:480</a></div>
                 </td>
             </tr>
 
@@ -2176,8 +2166,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="493"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:493</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="501"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:501</a></div>
                 </td>
             </tr>
 
@@ -2261,8 +2251,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="481"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:481</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="489"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:489</a></div>
                 </td>
             </tr>
 
@@ -2331,8 +2321,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="513"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:513</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="521"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:521</a></div>
                 </td>
             </tr>
 
@@ -2372,8 +2362,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="518"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:518</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="526"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:526</a></div>
                 </td>
             </tr>
 
@@ -2442,8 +2432,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="326"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:326</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="328"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:328</a></div>
                 </td>
             </tr>
 
@@ -2523,8 +2513,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="322"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:322</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="324"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:324</a></div>
                 </td>
             </tr>
 
@@ -2586,6 +2576,90 @@
         <tbody>
             <tr>
                 <td class="col-md-4">
+                    <a name="listLocationStyles"></a>
+                    <span class="name">
+                        <b>
+                            <span class="modifier">Private</span>
+                            listLocationStyles
+                        </b>
+                        <a href="#listLocationStyles"><span class="icon ion-ios-link"></span></a>
+                    </span>
+                </td>
+            </tr>
+            <tr>
+                <td class="col-md-4">
+                    <span class="modifier-icon icon ion-ios-reset"></span>
+                    <code>listLocationStyles()</code>
+                </td>
+            </tr>
+
+
+            <tr>
+                <td class="col-md-4">
+                    <div class="io-line">Defined in <a href="" data-line="451"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:451</a></div>
+                </td>
+            </tr>
+
+
+            <tr>
+                <td class="col-md-4">
+
+                    <div class="io-description">
+                        <b>Returns : </b>        <code><a href="https://www.typescriptlang.org/docs/handbook/basic-types.html" target="_blank" >any</a></code>
+
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <table class="table table-sm table-bordered">
+        <tbody>
+            <tr>
+                <td class="col-md-4">
+                    <a name="listStyles"></a>
+                    <span class="name">
+                        <b>
+                            <span class="modifier">Public</span>
+                            listStyles
+                        </b>
+                        <a href="#listStyles"><span class="icon ion-ios-link"></span></a>
+                    </span>
+                </td>
+            </tr>
+            <tr>
+                <td class="col-md-4">
+                    <span class="modifier-icon icon ion-ios-reset"></span>
+                    <code>listStyles()</code>
+                </td>
+            </tr>
+
+
+            <tr>
+                <td class="col-md-4">
+                    <div class="io-line">Defined in <a href="" data-line="446"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:446</a></div>
+                </td>
+            </tr>
+
+
+            <tr>
+                <td class="col-md-4">
+                    <div class="io-description"><p>Get menu style</p>
+</div>
+
+                    <div class="io-description">
+                        <b>Returns : </b>        <code><a href="https://www.typescriptlang.org/docs/handbook/basic-types.html" target="_blank" >any</a></code>
+
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <table class="table table-sm table-bordered">
+        <tbody>
+            <tr>
+                <td class="col-md-4">
                     <a name="ngAfterViewChecked"></a>
                     <span class="name">
                         <b>
@@ -2604,8 +2678,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="187"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:187</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="189"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:189</a></div>
                 </td>
             </tr>
 
@@ -2643,8 +2717,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="194"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:194</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="196"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:196</a></div>
                 </td>
             </tr>
 
@@ -2682,8 +2756,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="553"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:553</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="561"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:561</a></div>
                 </td>
             </tr>
 
@@ -2750,8 +2824,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="539"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:539</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="547"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:547</a></div>
                 </td>
             </tr>
 
@@ -2824,8 +2898,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="575"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:575</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="583"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:583</a></div>
                 </td>
             </tr>
 
@@ -2898,8 +2972,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="584"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:584</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="592"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:592</a></div>
                 </td>
             </tr>
 
@@ -2972,8 +3046,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="593"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:593</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="601"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:601</a></div>
                 </td>
             </tr>
 
@@ -3046,8 +3120,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="617"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:617</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="625"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:625</a></div>
                 </td>
             </tr>
 
@@ -3118,8 +3192,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="650"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:650</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="658"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:658</a></div>
                 </td>
             </tr>
 
@@ -3211,8 +3285,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="679"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:679</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="687"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:687</a></div>
                 </td>
             </tr>
 
@@ -3285,8 +3359,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="713"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:713</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="721"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:721</a></div>
                 </td>
             </tr>
 
@@ -3328,8 +3402,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="725"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:725</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="733"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:733</a></div>
                 </td>
             </tr>
 
@@ -3414,8 +3488,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="743"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:743</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="751"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:751</a></div>
                 </td>
             </tr>
 
@@ -3488,8 +3562,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="752"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:752</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="760"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:760</a></div>
                 </td>
             </tr>
 
@@ -3531,8 +3605,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="759"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:759</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="767"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:767</a></div>
                 </td>
             </tr>
 
@@ -3605,8 +3679,8 @@
 
             <tr>
                 <td class="col-md-4">
-                    <div class="io-line">Defined in <a href="" data-line="780"
-                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:780</a></div>
+                    <div class="io-line">Defined in <a href="" data-line="788"
+                            class="link-to-prism">src/auto-complete/auto-complete.component.ts:788</a></div>
                 </td>
             </tr>
 
@@ -3682,7 +3756,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="150" class="link-to-prism">src/auto-complete/auto-complete.component.ts:150</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="152" class="link-to-prism">src/auto-complete/auto-complete.component.ts:152</a></div>
                             </td>
                         </tr>
 
@@ -3710,7 +3784,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="127" class="link-to-prism">src/auto-complete/auto-complete.component.ts:127</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="129" class="link-to-prism">src/auto-complete/auto-complete.component.ts:129</a></div>
                             </td>
                         </tr>
 
@@ -3743,7 +3817,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="130" class="link-to-prism">src/auto-complete/auto-complete.component.ts:130</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="132" class="link-to-prism">src/auto-complete/auto-complete.component.ts:132</a></div>
                             </td>
                         </tr>
 
@@ -3771,7 +3845,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="131" class="link-to-prism">src/auto-complete/auto-complete.component.ts:131</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="133" class="link-to-prism">src/auto-complete/auto-complete.component.ts:133</a></div>
                             </td>
                         </tr>
 
@@ -3804,7 +3878,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="128" class="link-to-prism">src/auto-complete/auto-complete.component.ts:128</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="130" class="link-to-prism">src/auto-complete/auto-complete.component.ts:130</a></div>
                             </td>
                         </tr>
 
@@ -3841,7 +3915,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="122" class="link-to-prism">src/auto-complete/auto-complete.component.ts:122</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="124" class="link-to-prism">src/auto-complete/auto-complete.component.ts:124</a></div>
                             </td>
                         </tr>
 
@@ -3874,7 +3948,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="129" class="link-to-prism">src/auto-complete/auto-complete.component.ts:129</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="131" class="link-to-prism">src/auto-complete/auto-complete.component.ts:131</a></div>
                             </td>
                         </tr>
 
@@ -3907,7 +3981,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="125" class="link-to-prism">src/auto-complete/auto-complete.component.ts:125</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="127" class="link-to-prism">src/auto-complete/auto-complete.component.ts:127</a></div>
                             </td>
                         </tr>
 
@@ -3940,7 +4014,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="124" class="link-to-prism">src/auto-complete/auto-complete.component.ts:124</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="126" class="link-to-prism">src/auto-complete/auto-complete.component.ts:126</a></div>
                             </td>
                         </tr>
 
@@ -3962,7 +4036,7 @@
                 </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="135" class="link-to-prism">src/auto-complete/auto-complete.component.ts:135</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="137" class="link-to-prism">src/auto-complete/auto-complete.component.ts:137</a></div>
                             </td>
                         </tr>
 
@@ -3999,7 +4073,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="113" class="link-to-prism">src/auto-complete/auto-complete.component.ts:113</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="115" class="link-to-prism">src/auto-complete/auto-complete.component.ts:115</a></div>
                             </td>
                         </tr>
 
@@ -4027,7 +4101,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="132" class="link-to-prism">src/auto-complete/auto-complete.component.ts:132</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="134" class="link-to-prism">src/auto-complete/auto-complete.component.ts:134</a></div>
                             </td>
                         </tr>
 
@@ -4055,7 +4129,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="133" class="link-to-prism">src/auto-complete/auto-complete.component.ts:133</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="135" class="link-to-prism">src/auto-complete/auto-complete.component.ts:135</a></div>
                             </td>
                         </tr>
 
@@ -4088,7 +4162,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="152" class="link-to-prism">src/auto-complete/auto-complete.component.ts:152</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="154" class="link-to-prism">src/auto-complete/auto-complete.component.ts:154</a></div>
                             </td>
                         </tr>
 
@@ -4116,7 +4190,7 @@
                     </tr>
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="134" class="link-to-prism">src/auto-complete/auto-complete.component.ts:134</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="136" class="link-to-prism">src/auto-complete/auto-complete.component.ts:136</a></div>
                             </td>
                         </tr>
 
@@ -4146,7 +4220,7 @@
                 </tr>
                             <tr>
                                 <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="77" class="link-to-prism">src/auto-complete/auto-complete.component.ts:77</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="79" class="link-to-prism">src/auto-complete/auto-complete.component.ts:79</a></div>
                                 </td>
                             </tr>
                     <tr>
@@ -4201,7 +4275,7 @@
                 </tr>
                             <tr>
                                 <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="88" class="link-to-prism">src/auto-complete/auto-complete.component.ts:88</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="90" class="link-to-prism">src/auto-complete/auto-complete.component.ts:90</a></div>
                                 </td>
                             </tr>
                     <tr>
@@ -4259,7 +4333,7 @@
                 </tr>
                             <tr>
                                 <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="137" class="link-to-prism">src/auto-complete/auto-complete.component.ts:137</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="139" class="link-to-prism">src/auto-complete/auto-complete.component.ts:139</a></div>
                                 </td>
                             </tr>
 
@@ -4270,7 +4344,7 @@
                 </tr>
                             <tr>
                                 <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="141" class="link-to-prism">src/auto-complete/auto-complete.component.ts:141</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="143" class="link-to-prism">src/auto-complete/auto-complete.component.ts:143</a></div>
                                 </td>
                             </tr>
                     <tr>
@@ -4337,6 +4411,7 @@ import {finalize} from &#x27;rxjs/operators&#x27;;
 
 import {AutoCompleteOptions} from &#x27;../auto-complete-options.model&#x27;;
 import {AutoCompleteService} from &#x27;../auto-complete.service&#x27;;
+import {AutoCompleteStyles} from &#x27;../auto-complete-styles.model&#x27;;
 
 @Component({
   providers: [
@@ -4376,6 +4451,7 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
   @Input() public removeDuplicateSuggestions:boolean &#x3D; true;
   @Input() public selectionTemplate:TemplateRef&lt;any&gt;;
   @Input() public showResultsFirst:boolean;
+  @Input() public styles &#x3D; new AutoCompleteStyles;
   @Input() public template:TemplateRef&lt;any&gt;;
   @Input() public useIonInput:boolean &#x3D; false;
 
@@ -4760,8 +4836,14 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
   /**
    * Get menu style
    */
-  public getStyle():any {
+  public listStyles():any {
+    const listLocationStyles &#x3D; this.listLocationStyles();
+    return { ...listLocationStyles, ...this.styles.list };
+  }
+
+  private listLocationStyles():any {
     let location &#x3D; this.location;
+
     if (this.location &#x3D;&#x3D;&#x3D; &#x27;auto&#x27;) {
       const elementY &#x3D; this._getPosition(
         this.searchbarElem.nativeElement
@@ -5159,6 +5241,7 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
            [mode]&#x3D;&quot;options.mode &#x3D;&#x3D; null ? defaultOpts.mode : options.mode&quot;
            [disabled]&#x3D;&quot;disabled || (this.maxSelected !&#x3D;&#x3D; null &amp;&amp; this.selected.length &gt;&#x3D; this.maxSelected)&quot;
            [ngClass]&#x3D;&quot;{ &#x27;hidden&#x27;: !useIonInput, &#x27;loading&#x27;: isLoading }&quot;
+           [ngStyle]&#x3D;&quot;styles.searchbar&quot;
            (keyup.arrowDown)&#x3D;&quot;highlightItem(-1)&quot;
            (keyup.arrowUp)&#x3D;&quot;highlightItem(1)&quot;
            (keyup.enter)&#x3D;&quot;handleSelectTap($event, suggestions[focusedOption])&quot;
@@ -5189,6 +5272,7 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
                [spellcheck]&#x3D;&quot;options.spellcheck &#x3D;&#x3D; null ? defaultOpts.spellcheck : options.spellcheck&quot;
                [type]&#x3D;&quot;options.type &#x3D;&#x3D; null ? defaultOpts.type : options.type&quot;
                [ngClass]&#x3D;&quot;{ &#x27;hidden&#x27;: useIonInput, &#x27;loading&#x27;: isLoading, &#x27;disabled&#x27;: disabled || (this.maxSelected !&#x3D;&#x3D; null &amp;&amp; this.selected.length &gt;&#x3D; this.maxSelected) }&quot;
+               [ngStyle]&#x3D;&quot;styles.searchbar&quot;
                (keyup.arrowDown)&#x3D;&quot;highlightItem(-1)&quot;
                (keyup.arrowUp)&#x3D;&quot;highlightItem(1)&quot;
                (keyup.enter)&#x3D;&quot;handleSelectTap($event, suggestions[focusedOption])&quot;
@@ -5209,9 +5293,10 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
 &lt;/ng-template&gt;
 
 &lt;ul *ngIf&#x3D;&quot;!(disabled || (this.maxSelected !&#x3D;&#x3D; null &amp;&amp; this.selected.length &gt;&#x3D; this.maxSelected)) &amp;&amp; suggestions.length &gt; 0 &amp;&amp; showList&quot;
-    [ngStyle]&#x3D;&quot;getStyle()&quot;&gt;
+    [ngStyle]&#x3D;&quot;listStyles()&quot;&gt;
     &lt;li *ngFor&#x3D;&quot;let suggestion of suggestions| slice:0:maxResults; let index &#x3D; index&quot;
         [ngClass]&#x3D;&quot;{ &#x27;focus&#x27;: focusedOption &#x3D;&#x3D;&#x3D; index }&quot;
+        [ngStyle]&#x3D;&quot;styles.listItem&quot;
         (click)&#x3D;&quot;handleSelectTap($event, suggestion)&quot;
         (tap)&#x3D;&quot;handleSelectTap($event, suggestion)&quot;&gt;
         &lt;ng-template [ngTemplateOutlet]&#x3D;&quot;template || defaultTemplate&quot;
@@ -5229,8 +5314,8 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
 &lt;/ul&gt;
 
 &lt;ul *ngIf&#x3D;&quot;suggestions.length &#x3D;&#x3D;&#x3D; 0 &amp;&amp; showList &amp;&amp; options.noItems&quot;
-    [ngStyle]&#x3D;&quot;getStyle()&quot;&gt;
-    &lt;li&gt;
+    [ngStyle]&#x3D;&quot;listStyles()&quot;&gt;
+    &lt;li [ngStyle]&#x3D;&quot;styles.listItem&quot;&gt;
         &lt;ng-template [ngTemplateOutlet]&#x3D;&quot;emptyTemplate || defaultEmptyTemplate&quot;
                      [ngTemplateOutletContext]&#x3D;&quot;{
                         attrs:{
@@ -5338,7 +5423,7 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
 <script src="../js/libs/htmlparser.js"></script>
 <script src="../js/libs/deep-iterator.js"></script>
 <script>
-        var COMPONENT_TEMPLATE = '<div><ng-template #defaultSelection             let-attrs="attrs">    <ion-chip class="{{ attrs.removeButtonClasses }}"              [color]="attrs.removeButtonColor"              [outline]="true">        <ion-icon *ngIf="frontIcon"                  [name]="frontIcon"                  [slot]="\'start\'"                  color="primary"></ion-icon>        <ion-label>{{ attrs.label }}</ion-label>        <ion-icon *ngIf="attrs.removeButtonIcon"                  [name]="attrs.removeButtonIcon"                  [slot]="attrs.removeButtonSlot"></ion-icon>    </ion-chip></ng-template><div *ngIf="multi">    <div *ngFor="let item of selected"         class="selected-items"         (click)="removeItem(item)">        <ng-template [ngTemplateOutlet]="selectionTemplate || defaultSelection"                     [ngTemplateOutletContext]="{                            attrs: {                              data:                item,                              label:               getLabel(item),                              removeButtonClasses: removeButtonClasses,                              removeButtonColor:   removeButtonColor,                              removeButtonIcon:    removeButtonIcon,                              removeButtonSlot:    removeButtonSlot                            }                         }"></ng-template>    </div></div><ion-input #inputElem           [autocomplete]="enableBrowserAutoComplete ? \'on\' : \'off\'"           [name]="name"           (keyup)="keyupIonInput($event)"           (tap)="handleTap($event)"           [(ngModel)]="keyword"           (ngModelChange)="updateModel($event)"           [placeholder]="options.placeholder == null ? defaultOpts.placeholder : options.placeholder"           [type]="options.type == null ? defaultOpts.type : options.type"           [clearOnEdit]="options.clearOnEdit == null ? defaultOpts.clearOnEdit : options.clearOnEdit"           [clearInput]="options.clearInput == null ? defaultOpts.clearInput : options.clearInput"           [color]="options.color == null ? null : options.color"           [mode]="options.mode == null ? defaultOpts.mode : options.mode"           [disabled]="disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected)"           [ngClass]="{ \'hidden\': !useIonInput, \'loading\': isLoading }"           (keyup.arrowDown)="highlightItem(-1)"           (keyup.arrowUp)="highlightItem(1)"           (keyup.enter)="handleSelectTap($event, suggestions[focusedOption])"           (keyup.escape)="hideItemList()"           (ionFocus)="onFocus($event)"           (ionBlur)="onBlur($event)"></ion-input><ion-searchbar #searchbarElem               [autocomplete]="enableBrowserAutoComplete ? \'on\' : \'off\'"               [name]="name"               [animated]="options.animated == null ? defaultOpts.animated : options.animated"               (ionInput)="keyupIonSearchbar($event)"               (tap)="handleTap($event)"               [(ngModel)]="keyword"               (ngModelChange)="updateModel($event)"               [cancelButtonIcon]="options.cancelButtonIcon == null ? defaultOpts.cancelButtonIcon : options.cancelButtonIcon"               [cancelButtonText]="options.cancelButtonText == null ? defaultOpts.cancelButtonText : options.cancelButtonText"               [clearIcon]="options.clearIcon == null ? defaultOpts.clearIcon : options.clearIcon"               [color]="options.color == null ? null : options.color"               [showCancelButton]="options.showCancelButton == null ?                                        (defaultOpts.showCancelButton ? \'always\' : \'never\') :                                        (options.showCancelButton ? \'always\' : \'never\')"               [debounce]="options.debounce == null ? defaultOpts.debounce : options.debounce"               [placeholder]="options.placeholder == null ? defaultOpts.placeholder : options.placeholder"               [autocorrect]="options.autocorrect == null ? defaultOpts.autocorrect : options.autocorrect"               [mode]="options.mode == null ? defaultOpts.mode : options.mode"               [searchIcon]="options.searchIcon == null ? defaultOpts.searchIcon : options.searchIcon"               [spellcheck]="options.spellcheck == null ? defaultOpts.spellcheck : options.spellcheck"               [type]="options.type == null ? defaultOpts.type : options.type"               [ngClass]="{ \'hidden\': useIonInput, \'loading\': isLoading, \'disabled\': disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected) }"               (keyup.arrowDown)="highlightItem(-1)"               (keyup.arrowUp)="highlightItem(1)"               (keyup.enter)="handleSelectTap($event, suggestions[focusedOption])"               (keyup.escape)="hideItemList()"               (ionClear)="clickClear()"               (ionFocus)="onFocus($event)"               (ionBlur)="onBlur($event)"></ion-searchbar><ng-template #defaultTemplate             let-attrs="attrs">    <span [innerHTML]=\'attrs.label | boldprefix:attrs.keyword\'></span></ng-template><ng-template #defaultEmptyTemplate             let-attrs="attrs"             class="ion-text-center">    {{ options.noItems }}</ng-template><ul *ngIf="!(disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected)) && suggestions.length > 0 && showList"    [ngStyle]="getStyle()">    <li *ngFor="let suggestion of suggestions| slice:0:maxResults; let index = index"        [ngClass]="{ \'focus\': focusedOption === index }"        (click)="handleSelectTap($event, suggestion)"        (tap)="handleSelectTap($event, suggestion)">        <ng-template [ngTemplateOutlet]="template || defaultTemplate"                     [ngTemplateOutletContext]="{                        attrs:{                          data:               suggestion,                          label:              getLabel(suggestion),                          keyword:            keyword,                          formValue:          getFormValue(suggestion),                          labelAttribute:     getLabel(suggestion),                          formValueAttribute: getFormValue(suggestion)                        }                     }"></ng-template>    </li></ul><ul *ngIf="suggestions.length === 0 && showList && options.noItems"    [ngStyle]="getStyle()">    <li>        <ng-template [ngTemplateOutlet]="emptyTemplate || defaultEmptyTemplate"                     [ngTemplateOutletContext]="{                        attrs:{                          keyword: keyword                        }                     }"></ng-template>    </li></ul></div>'
+        var COMPONENT_TEMPLATE = '<div><ng-template #defaultSelection             let-attrs="attrs">    <ion-chip class="{{ attrs.removeButtonClasses }}"              [color]="attrs.removeButtonColor"              [outline]="true">        <ion-icon *ngIf="frontIcon"                  [name]="frontIcon"                  [slot]="\'start\'"                  color="primary"></ion-icon>        <ion-label>{{ attrs.label }}</ion-label>        <ion-icon *ngIf="attrs.removeButtonIcon"                  [name]="attrs.removeButtonIcon"                  [slot]="attrs.removeButtonSlot"></ion-icon>    </ion-chip></ng-template><div *ngIf="multi">    <div *ngFor="let item of selected"         class="selected-items"         (click)="removeItem(item)">        <ng-template [ngTemplateOutlet]="selectionTemplate || defaultSelection"                     [ngTemplateOutletContext]="{                            attrs: {                              data:                item,                              label:               getLabel(item),                              removeButtonClasses: removeButtonClasses,                              removeButtonColor:   removeButtonColor,                              removeButtonIcon:    removeButtonIcon,                              removeButtonSlot:    removeButtonSlot                            }                         }"></ng-template>    </div></div><ion-input #inputElem           [autocomplete]="enableBrowserAutoComplete ? \'on\' : \'off\'"           [name]="name"           (keyup)="keyupIonInput($event)"           (tap)="handleTap($event)"           [(ngModel)]="keyword"           (ngModelChange)="updateModel($event)"           [placeholder]="options.placeholder == null ? defaultOpts.placeholder : options.placeholder"           [type]="options.type == null ? defaultOpts.type : options.type"           [clearOnEdit]="options.clearOnEdit == null ? defaultOpts.clearOnEdit : options.clearOnEdit"           [clearInput]="options.clearInput == null ? defaultOpts.clearInput : options.clearInput"           [color]="options.color == null ? null : options.color"           [mode]="options.mode == null ? defaultOpts.mode : options.mode"           [disabled]="disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected)"           [ngClass]="{ \'hidden\': !useIonInput, \'loading\': isLoading }"           [ngStyle]="styles.searchbar"           (keyup.arrowDown)="highlightItem(-1)"           (keyup.arrowUp)="highlightItem(1)"           (keyup.enter)="handleSelectTap($event, suggestions[focusedOption])"           (keyup.escape)="hideItemList()"           (ionFocus)="onFocus($event)"           (ionBlur)="onBlur($event)"></ion-input><ion-searchbar #searchbarElem               [autocomplete]="enableBrowserAutoComplete ? \'on\' : \'off\'"               [name]="name"               [animated]="options.animated == null ? defaultOpts.animated : options.animated"               (ionInput)="keyupIonSearchbar($event)"               (tap)="handleTap($event)"               [(ngModel)]="keyword"               (ngModelChange)="updateModel($event)"               [cancelButtonIcon]="options.cancelButtonIcon == null ? defaultOpts.cancelButtonIcon : options.cancelButtonIcon"               [cancelButtonText]="options.cancelButtonText == null ? defaultOpts.cancelButtonText : options.cancelButtonText"               [clearIcon]="options.clearIcon == null ? defaultOpts.clearIcon : options.clearIcon"               [color]="options.color == null ? null : options.color"               [showCancelButton]="options.showCancelButton == null ?                                        (defaultOpts.showCancelButton ? \'always\' : \'never\') :                                        (options.showCancelButton ? \'always\' : \'never\')"               [debounce]="options.debounce == null ? defaultOpts.debounce : options.debounce"               [placeholder]="options.placeholder == null ? defaultOpts.placeholder : options.placeholder"               [autocorrect]="options.autocorrect == null ? defaultOpts.autocorrect : options.autocorrect"               [mode]="options.mode == null ? defaultOpts.mode : options.mode"               [searchIcon]="options.searchIcon == null ? defaultOpts.searchIcon : options.searchIcon"               [spellcheck]="options.spellcheck == null ? defaultOpts.spellcheck : options.spellcheck"               [type]="options.type == null ? defaultOpts.type : options.type"               [ngClass]="{ \'hidden\': useIonInput, \'loading\': isLoading, \'disabled\': disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected) }"               [ngStyle]="styles.searchbar"               (keyup.arrowDown)="highlightItem(-1)"               (keyup.arrowUp)="highlightItem(1)"               (keyup.enter)="handleSelectTap($event, suggestions[focusedOption])"               (keyup.escape)="hideItemList()"               (ionClear)="clickClear()"               (ionFocus)="onFocus($event)"               (ionBlur)="onBlur($event)"></ion-searchbar><ng-template #defaultTemplate             let-attrs="attrs">    <span [innerHTML]=\'attrs.label | boldprefix:attrs.keyword\'></span></ng-template><ng-template #defaultEmptyTemplate             let-attrs="attrs"             class="ion-text-center">    {{ options.noItems }}</ng-template><ul *ngIf="!(disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected)) && suggestions.length > 0 && showList"    [ngStyle]="listStyles()">    <li *ngFor="let suggestion of suggestions| slice:0:maxResults; let index = index"        [ngClass]="{ \'focus\': focusedOption === index }"        [ngStyle]="styles.listItem"        (click)="handleSelectTap($event, suggestion)"        (tap)="handleSelectTap($event, suggestion)">        <ng-template [ngTemplateOutlet]="template || defaultTemplate"                     [ngTemplateOutletContext]="{                        attrs:{                          data:               suggestion,                          label:              getLabel(suggestion),                          keyword:            keyword,                          formValue:          getFormValue(suggestion),                          labelAttribute:     getLabel(suggestion),                          formValueAttribute: getFormValue(suggestion)                        }                     }"></ng-template>    </li></ul><ul *ngIf="suggestions.length === 0 && showList && options.noItems"    [ngStyle]="listStyles()">    <li [ngStyle]="styles.listItem">        <ng-template [ngTemplateOutlet]="emptyTemplate || defaultEmptyTemplate"                     [ngTemplateOutletContext]="{                        attrs:{                          keyword: keyword                        }                     }"></ng-template>    </li></ul></div>'
     var COMPONENTS = [{'name': 'AppComponent', 'selector': 'app-root'},{'name': 'AutoCompleteComponent', 'selector': 'ion-auto-complete'},{'name': 'CustomTemplateComponent', 'selector': 'custom-template'},{'name': 'HomePage', 'selector': 'home-page'},{'name': 'MultiFunctionComponent', 'selector': 'multi-function'},{'name': 'SimpleFunctionComponent', 'selector': 'simple-function'},{'name': 'SimpleServiceComponent', 'selector': 'simple-service'}];
     var DIRECTIVES = [];
     var ACTUAL_COMPONENT = {'name': 'AutoCompleteComponent'};

--- a/docs/coverage.html
+++ b/docs/coverage.html
@@ -268,6 +268,18 @@
                 <span class="coverage-count">(0/20)</span>
             </td>
         </tr>
+        <tr class="low">
+            <td>
+                <!-- miscellaneous -->
+                <a href="./classes/AutoCompleteStyles.html">src/auto-complete-styles.model.ts</a>
+            </td>
+            <td>class</td>
+            <td>AutoCompleteStyles</td>
+            <td align="right" data-sort="0">
+                <span class="coverage-percent">0 %</span>
+                <span class="coverage-count">(0/4)</span>
+            </td>
+        </tr>
         <tr class="very-good">
             <td>
                 <!-- miscellaneous -->
@@ -287,9 +299,9 @@
             </td>
             <td>component</td>
             <td>AutoCompleteComponent</td>
-            <td align="right" data-sort="29">
-                <span class="coverage-percent">29 %</span>
-                <span class="coverage-count">(26/89)</span>
+            <td align="right" data-sort="28">
+                <span class="coverage-percent">28 %</span>
+                <span class="coverage-count">(26/91)</span>
             </td>
         </tr>
         <tr class="medium">

--- a/docs/images/coverage-badge-documentation.svg
+++ b/docs/images/coverage-badge-documentation.svg
@@ -4,6 +4,6 @@
         <rect id="svg_2" height="20" width="40" y="0" x="92" stroke-width="1.5" stroke="#d8604b" fill="#d8604b" rx="7" ry="7"/>
         <rect id="svg_3" height="20" width="22" y="0" x="92" stroke-width="1.5" stroke="#d8604b" fill="#d8604b"/>
         <text xml:space="preserve" text-anchor="start" font-family="Helvetica, Arial, sans-serif" font-size="12" id="svg_4" y="14" x="6" stroke-width="0" stroke="#5d5d5d" fill="#ffffff">documentation</text>
-        <text xml:space="preserve" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" id="svg_5" y="14" x="112" stroke-width="0" stroke="#5d5d5d" fill="#ffffff" style="text-anchor: middle">11%</text>
+        <text xml:space="preserve" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" id="svg_5" y="14" x="112" stroke-width="0" stroke="#5d5d5d" fill="#ffffff" style="text-anchor: middle">10%</text>
     </g>
 </svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -383,6 +383,8 @@ getResults(keyword:string):Observable&lt;any[]&gt; {
 <ul>
 <li><p>In addition to the searchbar options, <code>ion-auto-complete</code> also supports the following option attributes:</p>
 </li>
+<li><p><code>[styles]</code> (AutoCompleteStyles) - custom styles to be passed to <code>ngStyle</code> on elements within the Shadow DOM. Available element keys are: <code>list</code>; <code>listItem</code>; and <code>searchbar</code>.</p>
+</li>
 <li><p><code>[template]</code> (TemplateRef) - custom template reference for your auto complete items (see below).</p>
 </li>
 <li><p><code>[emptytemplate]</code> (TemplateRef) - custom template reference for your auto complete no items display.</p>

--- a/docs/overview.html
+++ b/docs/overview.html
@@ -525,7 +525,7 @@
             <div class="card text-center">
                 <div class="card-block">
                     <h4 class="card-title"><span class="icon ion-ios-paper"></span></h4>
-                    <p class="card-text">5 Classes</p>
+                    <p class="card-text">6 Classes</p>
                 </div>
             </div>
         </div>

--- a/src/auto-complete-styles.model.ts
+++ b/src/auto-complete-styles.model.ts
@@ -1,0 +1,5 @@
+export class AutoCompleteStyles {
+  public list = {};
+  public listItem = {};
+  public searchbar = {};
+}

--- a/src/auto-complete/auto-complete.component.html
+++ b/src/auto-complete/auto-complete.component.html
@@ -49,6 +49,7 @@
            [mode]="options.mode == null ? defaultOpts.mode : options.mode"
            [disabled]="disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected)"
            [ngClass]="{ 'hidden': !useIonInput, 'loading': isLoading }"
+           [ngStyle]="styles.searchbar"
            (keyup.arrowDown)="highlightItem(-1)"
            (keyup.arrowUp)="highlightItem(1)"
            (keyup.enter)="handleSelectTap($event, suggestions[focusedOption])"
@@ -79,6 +80,7 @@
                [spellcheck]="options.spellcheck == null ? defaultOpts.spellcheck : options.spellcheck"
                [type]="options.type == null ? defaultOpts.type : options.type"
                [ngClass]="{ 'hidden': useIonInput, 'loading': isLoading, 'disabled': disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected) }"
+               [ngStyle]="styles.searchbar"
                (keyup.arrowDown)="highlightItem(-1)"
                (keyup.arrowUp)="highlightItem(1)"
                (keyup.enter)="handleSelectTap($event, suggestions[focusedOption])"
@@ -99,9 +101,10 @@
 </ng-template>
 
 <ul *ngIf="!(disabled || (this.maxSelected !== null && this.selected.length >= this.maxSelected)) && suggestions.length > 0 && showList"
-    [ngStyle]="getStyle()">
+    [ngStyle]="listStyles()">
     <li *ngFor="let suggestion of suggestions| slice:0:maxResults; let index = index"
         [ngClass]="{ 'focus': focusedOption === index }"
+        [ngStyle]="styles.listItem"
         (click)="handleSelectTap($event, suggestion)"
         (tap)="handleSelectTap($event, suggestion)">
         <ng-template [ngTemplateOutlet]="template || defaultTemplate"
@@ -119,8 +122,8 @@
 </ul>
 
 <ul *ngIf="suggestions.length === 0 && showList && options.noItems"
-    [ngStyle]="getStyle()">
-    <li>
+    [ngStyle]="listStyles()">
+    <li [ngStyle]="styles.listItem">
         <ng-template [ngTemplateOutlet]="emptyTemplate || defaultEmptyTemplate"
                      [ngTemplateOutletContext]="{
                         attrs:{

--- a/src/auto-complete/auto-complete.component.ts
+++ b/src/auto-complete/auto-complete.component.ts
@@ -18,6 +18,7 @@ import {finalize} from 'rxjs/operators';
 
 import {AutoCompleteOptions} from '../auto-complete-options.model';
 import {AutoCompleteService} from '../auto-complete.service';
+import {AutoCompleteStyles} from '../auto-complete-styles.model';
 
 @Component({
   providers: [
@@ -57,6 +58,7 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
   @Input() public removeDuplicateSuggestions:boolean = true;
   @Input() public selectionTemplate:TemplateRef<any>;
   @Input() public showResultsFirst:boolean;
+  @Input() public styles = new AutoCompleteStyles;
   @Input() public template:TemplateRef<any>;
   @Input() public useIonInput:boolean = false;
 
@@ -441,8 +443,14 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
   /**
    * Get menu style
    */
-  public getStyle():any {
+  public listStyles():any {
+    const listLocationStyles = this.listLocationStyles();
+    return { ...listLocationStyles, ...this.styles.list };
+  }
+
+  private listLocationStyles():any {
     let location = this.location;
+
     if (this.location === 'auto') {
       const elementY = this._getPosition(
         this.searchbarElem.nativeElement


### PR DESCRIPTION
# I'm submitting a...

- [ ] Bug Fix
- [x] Feature
- [ ] Other (Refactoring, Added tests, Documentation, ...)

### Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
- [x] Docs have been added / updated (for bug fixes / features)

### Description

While the `ion-auto-complete` element can be styled within a project's stylesheet, nested elements can not be directly styled. Options exist to pass some styles to the pre-defined options provided on Ionic elements, however, these options are limited both in number and element scope.

Styles can be provided to the `ion-auto-complete` via the `styles` input:
```
  <ion-auto-complete
    [styles]="{
      searchbar: {
        background: 'white'
      }
      list: {
        paddingLeft: '5rem'
      },
      input: {
        background: 'green',
        paddingTop: '1rem'
      }
    }"
  ></ion-auto-complete>
```

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Does this PR affects any existing issues?

- [ ] Yes
- [x] No