### PR TITLE
Fix for keyboard highlighting of selections

### DIFF
--- a/src/auto-complete/auto-complete.component.ts
+++ b/src/auto-complete/auto-complete.component.ts
@@ -565,7 +565,7 @@ export class AutoCompleteComponent implements AfterViewChecked, ControlValueAcce
       this.showItemList();
     }
 
-    const max = this.suggestions.length - 1;
+    const max = this.suggestions.length > this.maxResults ? this.maxResults - 1 : this.suggestions.length - 1;
 
     if (direction < 0) {
       if (this.focusedOption === -1 || this.focusedOption === max) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {AutoCompleteComponent} from './auto-complete/auto-complete.component';
 import {BoldPrefix} from './bold-prefix.pipe';
 
 export * from './auto-complete-options.model';
+export * from './auto-complete-styles.model';
 
 export * from './auto-complete.service';
 


### PR DESCRIPTION
<!-- Make sure your title is clear -->
<!-- To mark a task, use [x]. -->

# I'm submitting a...

- [x] Bug Fix
- [ ] Feature
- [ ] Other (Refactoring, Added tests, Documentation, ...)

### Description

Fixes an issue where the keyboard up/down arrow is used to highlight a selection.
At the moment the highlight is bound to the number of suggestions, but the `maxResults` parameter means that not all suggestions are visible.

As a result it is possible to move the highlight beyond the visible suggestions, which will then result in a non-visible suggestion being selected when the user presses enter/tab to leave the field.

This fix prevents the keyboard up/down arrow from moving beyond the visible suggestions.

Also, adding export for `AutoCompleteStyles` object to allow creation of object that can be shared between several fields.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Does this PR affects any existing issues?

- [ ] Yes
- [x] No
